### PR TITLE
Integration with xbdeals website

### DIFF
--- a/js/helpers.js
+++ b/js/helpers.js
@@ -8,7 +8,7 @@
  */
 function getPriceWithTaxes(containerDOMElement, priceDOMElement, taxes, currency = 'ARS') {
   const priceText = containerDOMElement.querySelector(priceDOMElement).textContent;
-  const priceIsFree = priceText.includes('Free') || priceText.includes('Gratuito');
+  const priceIsFree = priceText.includes('Free') || priceText.includes('FREE') || priceText.includes('Gratuito');
   const priceWithTaxes = (p) => (p + p * (taxes.ganancias + taxes.pais)).toFixed(2)
 
   if (priceIsFree) {

--- a/js/index.js
+++ b/js/index.js
@@ -27,6 +27,10 @@ function handleMutationsInit() {
     }
   }
 
+  if (hostname.includes("xbdeals.net") && pathname.includes("ar-store")) {
+    handleXbDeals();
+  }
+
   if (hostname.includes('xbox')) {
 
     if (pathname.includes('games/all-games')) {

--- a/js/xbox/xbdeals.js
+++ b/js/xbox/xbdeals.js
@@ -1,0 +1,102 @@
+
+/**
+ * Calculates the final prices with getPriceWithTaxes based on the prices found on the 
+ * https://xbdeals.net/ website.
+ * Then appends a badge to each game card.
+ *
+ * Tested on:
+ * https://xbdeals.net/ar-store/
+ */
+function handleXbDeals() {
+    handleXbDealsFeatured();
+    handleXbDealsDiscounts();
+    handleXbDealsGamePage();
+}
+
+/**
+ * Calculates the final prices with getPriceWithTaxes based on the prices found on the 
+ * home page of https://xbdeals.net/ website.
+ * Then appends a badge to each game card.
+ */
+function handleXbDealsFeatured() {
+    const gameCards = document.querySelectorAll('.game-collection-item-details-price');
+    
+    for (var i = 0; i < gameCards.length; i++) {
+        const card = gameCards[i];
+
+        if (card.className.includes('impuestito') === false) {
+            const regularPriceCard = card.querySelector('.game-collection-item-regular-price');
+            const bonusPriceCard = card.querySelector('.game-collection-item-bonus-price');
+            const discountPriceCard = card.querySelector('.game-collection-item-discount-price');
+    
+            var price;
+            if (discountPriceCard) {
+                price = getPriceWithTaxes(card, '.game-collection-item-discount-price', tax, 'ARS');
+            } else if (bonusPriceCard) {
+                price = getPriceWithTaxes(card, '.game-collection-item-bonus-price', tax, 'ARS');
+            } else if (regularPriceCard) {
+                price = getPriceWithTaxes(card, '.game-collection-item-regular-price', tax, 'ARS');
+            }
+    
+            if (price !== undefined) {
+                drawBadge(price, card);
+                card.classList.add('impuestito');
+            }
+        }
+
+    }
+}
+
+/**
+ * Calculates the final prices with getPriceWithTaxes based on the prices found on the 
+ * list of https://xbdeals.net/ website.
+ * Then appends a badge to each game card.
+ */
+function handleXbDealsDiscounts() {
+    const gameCards = document.querySelectorAll('.game-collection-item-details p[itemprop=offers]');
+
+    for (var i = 0; i < gameCards.length; i++) {
+        const card = gameCards[i];
+        if (card.className.includes('impuestito') === false) {
+            
+            const price = getPriceWithTaxes(card, 'span[itemprop=price]', tax, 'ARS');
+            drawBadge(price, card);
+            card.classList.add('impuestito');
+  
+        }
+    }
+}
+
+/**
+ * Calculates the final price with getPriceWithTaxes based on the price found on 
+ * a game's page inside https://xbdeals.net/ website.
+ * Then appends a badge to the game card.
+ */
+function handleXbDealsGamePage() {
+    const card = document.querySelector('.game-buy-button-right p[itemprop=offers]');
+    if (card && card.className.includes('impuestito') === false) {
+        const regularPriceCard = card.querySelector('.game-collection-item-regular-price');
+        const bonusPriceCard = card.querySelector('.game-collection-item-bonus-price');
+        const discountPriceCard = card.querySelector('.game-collection-item-discount-price');
+
+        var price;
+        if (discountPriceCard) {
+            price = getPriceWithTaxes(card, '.game-collection-item-discount-price', tax, 'ARS');
+        } else if (bonusPriceCard) {
+            price = getPriceWithTaxes(card, '.game-collection-item-bonus-price', tax, 'ARS');
+        } else if (regularPriceCard) {
+            price = getPriceWithTaxes(card, '.game-collection-item-regular-price', tax, 'ARS');
+        }
+
+        if (price !== undefined) {
+            const buyButtonContainer = document.querySelector('.game-buy-button-href').parentElement.parentElement;
+            const priceContainer = document.createElement('div');
+            priceContainer.classList.add('col-xs-12');
+            priceContainer.style.textAlign = "right";
+            drawBadge(price, priceContainer);
+            buyButtonContainer.appendChild(priceContainer);
+            card.classList.add('impuestito');
+        }
+
+    }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -14,6 +14,7 @@
         "*://*.playstation.com/en-us/*",
         "*://*.xbox.com/es-AR/*",
         "*://*.xbox.com/es-ar/*",
+        "*://*.xbdeals.net/ar-store*",
         "*://*.nintendo.com/*",
         "*://*.nintendo.com.ar/*"
       ],
@@ -25,6 +26,7 @@
         "js/helpers.js",
         "js/playstation/playstation.js",
         "js/xbox/xbox.js",
+        "js/xbox/xbdeals.js",
         "js/nintendo/nintendo.js"
       ],
       "run_at": "document_idle"


### PR DESCRIPTION
Buenas. Está muy buena la extensión.
Agregué la integración con la web de xbdeals que personalmente la uso mucho.
Hay tres formas diferentes en las que se muestran los precios:

1. En la home: hay que diferenciar si hay una oferta, un descuento por suscripción, o un precio normal.
2. En un listado (ya sea abriendo una de las filas de la home o al ingresar una búsqueda): en este caso hay una tag oculta que tiene el precio actual.
3. En la página de un juego en particular: se lee el juego igual que en la home, solo que tuve que agregar el badge afuera del contenedor de precios porque se rompía el layout de ellos.

De por sí, el tamaño del texto de la extensión queda grande para esta web. Pero podría ser una mejora futura, poder personalizar ese tamaño dependiendo de la web.